### PR TITLE
CLOUD-12 Implement CircleCI workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,23 +1,177 @@
 version: 2.1
 
-# Define the jobs we want to run for this project
-jobs:
-  build:
+executors:
+  go-exec:
     docker:
-      - image: cimg/base:2023.03
-    steps:
-      - checkout
-      - run: echo "this is the build job"
-  test:
-    docker:
-      - image: cimg/base:2023.03
-    steps:
-      - checkout
-      - run: echo "this is the test job"
+      - image: cimg/go:1.21.4
 
-# Orchestrate our job run sequence
+# Each job specifies a number of steps which are executed in a docker container.
+jobs:
+
+  # Pull the src code from the repository and add it to the workspace.
+  # Any job that uses the src code must require this job to finish beforehand.
+  pull:
+    executor: go-exec
+    steps:
+      # A special step used to checkout the source code.
+      - checkout
+      # A special step used to persist a file/folder to be used by another job
+      # in the workflow.
+      - persist_to_workspace:
+          root: .
+          paths: .
+
+  # Run the golang linters using golangci-lint. The linters that will be run are
+  # defined inside the .golangci.yml file.
+  lint:
+    executor: go-exec
+    steps:
+      # A special step used to attach the workflow's workspace to the current
+      # executor. The full contents of the workspace are downloaded and copied
+      # into the directory the workspace is being attached at.
+      - attach_workspace:
+          at: .
+      # Install golangci-lint, see: https://golangci-lint.run/usage/install/.
+      - run:
+          environment:
+            GOLANGCI_LINT_VERSION: v1.55.2
+          command: |
+            wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s ${GOLANGCI_LINT_VERSION}
+      # Run the linters.
+      - run: golangci-lint run -v ./...
+
+  # Run the unit tests.
+  unit_tests:
+    executor: go-exec
+    steps:
+      # Attach the workspace to the current executor.
+      - attach_workspace:
+          at: .
+      # TODO: unit tests should be run with the flag -short in order to
+      # differentiate them from the integration tests.
+      # go test -short -shuffle=on -race -coverprofile /app/coverage.out /app/...
+      # The unit tests reside inside the src folder.
+      - run: go test ./src/...
+
+  # Run the integration tests.
+  integration_tests:
+    executor: go-exec
+    steps:
+      # Attach the workspace to the current executor.
+      - attach_workspace:
+          at: .
+      # Allows docker commands to be run locally. This is required to get access
+      # to docker from within the executor.
+      - setup_remote_docker
+      # The integration tests might require running additional services.
+      # All of these are defined in the docker-compose file.
+      - run: docker-compose up -d --build
+
+      # Note that we are running a docker container inside a docker container.
+      # The `integration_tests` is run from inside `go-exec`. A well known
+      # shortcoming is that you can't mount a volume from one docker container
+      # to another. As a workaround we will copy the contents of the repository
+      # into the integration_tests container and run `docker-compose exec`.
+      - run: docker cp ./ integration_tests:/usr/service/
+      - run: docker-compose exec -T integration_tests go test ./src/...
+
+      # Stopping and removing containers, volumes, and networks makes sure tests
+      # are not broken due to data that has persisted from the last test run.
+      - run: docker-compose down --volumes --remove-orphans
+
+  # TODO: Add e2e tests.
+  # Run e2e tests.
+  e2e_tests:
+    executor: go-exec
+    steps:
+      - run: echo "e2e tests should be run"
+
+  # Build a docker image with the service binary and push it to DockerHub.
+  # The image will be tagged with the git branch tag. This job should be run
+  # only on `git tag`.
+  build_and_push:
+    executor: go-exec
+    environment:
+      TAG: << pipeline.git.tag >>
+    steps:
+      # Attach the workspace to the current executor.
+      - attach_workspace:
+          at: .
+      # Allows docker commands to be run locally.
+      - setup_remote_docker
+      # Build the docker image and push it to docker hub.
+      - run: docker build -t $DOCKERHUB_USER/booking-service:$TAG .
+      - run: echo $DOCKERHUB_PASSWORD | docker login -u $DOCKERHUB_USER --password-stdin
+      - run: docker push $DOCKERHUB_USER/booking-service:$TAG
+
+
+# The workflows describe the jobs and the order in which they need to be run.
 workflows:
-  build_and_test:
+
+  # The dev-pipeline is run when submitting pull requests. Linter checks are run
+  # and the src code is tested with unit and integration tests.
+  dev-pipeline:
+    when:
+      not:
+        equal: [ main, << pipeline.git.branch >> ]
+
     jobs:
-      - build
-      - test
+      # Pull the src code.
+      - pull
+
+      # Linting and testing should run after the code was pulled.
+      - lint:
+          requires:
+            - pull
+      - unit_tests:
+          requires:
+            - pull
+      - integration_tests:
+          requires:
+            - pull
+
+  # The prod-pipeline is run when PRs are merged into the main branch. To make
+  # sure all components function properly e2e tests are run.
+  prod-pipeline:
+    when:
+      equal: [ main, << pipeline.git.branch >> ]
+
+    jobs:
+      # Pull the src code.
+      - pull
+
+      # Run e2e tests.
+      - e2e_tests:
+          requires:
+            - pull
+
+  # The deploy-pipeline is run when a commit from the main branch is tagged.
+  # A docker image of the service is built and pushed to docker hub.
+  deploy-pipeline:
+    # when:
+    #   and:
+    #     - equal: [ main, << pipeline.git.branch >> ]
+    #     - matches: { pattern: "^v.*", value: << pipeline.git.tag >> }
+
+    jobs:
+      # Pull the src code.
+      - pull:
+          filters: # required since `build_and_push` has filters
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
+
+      # Note that we need to provide the `DockerHub` context variables in order
+      # to login to DockerHub.
+      - build_and_push:
+          context: DockerHub
+          requires:
+            - pull
+          filters:
+            # Trigger only on tags.
+            tags:
+              only: /^v.*/
+            # Don't trigger on branches.
+            branches:
+              ignore: /.*/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Booking-Service
 
+[![CircleCI](https://dl.circleci.com/status-badge/img/circleci/RGExmu1KKSYDZZz3vWH7qN/RwUMAPoUWDv5gGRRfFrmpe/tree/main.svg?style=svg&circle-token=f31e3710e89672aa847d407fb73beebf9395ff5e)](https://dl.circleci.com/status-badge/redirect/circleci/RGExmu1KKSYDZZz3vWH7qN/RwUMAPoUWDv5gGRRfFrmpe/tree/main)
+
 The `Booking` service manages the bookings on the platform.
 It can be used to create new bookings by existing users for existing events.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,8 @@ version: "3"
 
 services:
 
-  bookingservice:
+  booking-service:
+    container_name: booking-service
     build: .
     environment:
       - BOOKING_MONGO_HOST=mongodb
@@ -10,20 +11,27 @@ services:
       - BOOKING_MONGO_USERNAME=bookingservice
       - BOOKING_MONGO_PASSWORD=mongo_password
       - BOOKING_MONGO_DATABASE=bookings
-      - HTTP_SERVER_LISTEN=:80
+      - HTTP_SERVER_LISTEN=:8080
       - MESSAGE_BUS_HOST=rabbitmq
       - MESSAGE_BUS_PORT=5672
       - MESSAGE_BUS_USERNAME=bookingservice
       - MESSAGE_BUS_PASSWORD=rabbitmq_password
     ports:
-      - "10090:80"
+      - "8080:8080"
+    expose:
+      - 8080
     depends_on:
       mongodb:
         condition: service_started
       rabbitmq:
         condition: service_healthy
+    # Note that healthcheck will not work because this particular docker image
+    # is built from scratch and does not have curl installed.
+    # healthcheck:
+    #   test: curl -f http://localhost:8080/healthz || exit 1
 
   mongodb:
+    container_name: mongodb
     image: mongo:4.4.4
     expose:
       - 27017
@@ -35,6 +43,7 @@ services:
     #   - ./db-data/mogno:/data/db
 
   rabbitmq:
+    container_name: rabbitmq
     image: rabbitmq:3.12.7-alpine
     expose:
       - 5672
@@ -48,3 +57,33 @@ services:
       - RABBITMQ_DEFAULT_PASS=rabbitmq_password
     # volumes:
     #   -
+
+  integration_tests:
+    container_name: integration_tests
+    image: golang:1.21.2-alpine
+    # When running integration tests with CircleCI we need to first run
+    # docker-compose, then copy the src code inside this container, and only
+    # after that run the tests. Thus, the container will simply sleep.
+    # command: go test ./src/... # for local tests uncomment this line
+    command: sleep infinity
+    working_dir: '/usr/service'
+    depends_on:
+      booking-service-ready: # note we are using another service for healthchecks
+        condition: service_healthy
+      mongodb:
+        condition: service_started
+      rabbitmq:
+        condition: service_healthy
+    volumes:
+      - '.:/usr/service'
+
+  # This service is used as a workaround for health checking.
+  booking-service-ready:
+    container_name: booking-service-ready
+    image: alpine/curl:8.1.2
+    command: sleep infinity
+    healthcheck:
+      test: curl -f booking-service:8080/healthz || exit 1
+      interval: 10s
+      timeout: 30s
+      retries: 5


### PR DESCRIPTION
Repalce the dummy CircleCI config file with a fully functional configuration.

Introduce two separate workflows:
 * dev-pipeline will be run on all branches except main
 * prod-pipeline will be run only on the main branch

In addition make sure that pushing to docker hub is performed only when the commit is tagged.